### PR TITLE
Pimcore 6 / Symfony 4 compatibility

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -3,7 +3,7 @@
 namespace DataDictionaryBundle\Controller;
 
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use DataDictionaryBundle\Graph\Presenters\GraphViz;
@@ -49,7 +49,7 @@ class DefaultController extends AdminController
         return $response;
     }
     /**
-     * @Route("/test", name="dataDictonaryImage")
+     * @Route("/test", name="dataDictonaryTest")
      * @param Graph $graph
      * @return Response
      * @throws \Exception

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,23 +8,17 @@ services:
         # this means you cannot fetch services directly from the container via $container->get()
         # if you need to do this, you can override this setting on individual services
         public: true
+
     DataDictionaryBundle\Controller\:
         resource: '../../Controller'
-        public: true
         tags: ['controller.service_arguments']
 
     datadictionary.defaultclass:
         class: DataDictionaryBundle\Graph\Visitor\Factory\DefaultClass
-        public: true
-        autowiring: true
-        autoconfigure: true
         tags: ['datadictionary']
 
     data_dictionary.graph:
         class: DataDictionaryBundle\Graph\Graph
-        autowiring: true
-        autoconfigure: true
-        public: true
         calls:
             - method: setVisitors
               arguments: [!tagged 'datadictionary']

--- a/src/Resources/public/js/pimcore/startup.js
+++ b/src/Resources/public/js/pimcore/startup.js
@@ -36,7 +36,7 @@ pimcore.plugin.dataDictionaryBundle = Class.create(pimcore.plugin.admin, {
         return new Ext.Panel({
             id: panelId,
             title: t('Data Dictionary'),
-            iconCls: 'pimcore_icon_multihref',
+            icon: '/bundles/pimcoreadmin/img/flat-color-icons/tree_structure.svg',
             border: false,
             layout: 'fit',
             closable: true,


### PR DESCRIPTION
Without these changes I get 
`The configuration key "autowiring" is unsupported for definition "datadictionary.defaultclass"`
This is quite clear because the service parameter for autowiring is named `autowire`. I just removed it from the service as it is already present in `_default`.

The second problem is that annotation routing does not work because the wrong `Route` class gets used. I also fixed that. Now it works in Pimcore 6.3

Solves #19 